### PR TITLE
Remove require styling

### DIFF
--- a/src/template.ejs
+++ b/src/template.ejs
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>CSS Modules Styling Demo</title>
+    <title>CSS Modules JSS Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="style.css" />
   </head>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 var webpack = require('webpack');
-var styling = require('styling');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var ReactToHtmlPlugin = require('react-to-html-webpack-plugin');
 


### PR DESCRIPTION
This PR `require('styling');` from webpack config and updates the template title.
This was necessary since the `styling` dependency was removed.
